### PR TITLE
Lsj/login api connect

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,14 @@
-import 'package:easyback/services/api_auths.dart';
+import 'package:easyback/services/APIAuths.dart';
+import 'package:easyback/services/APIDeployInfos.dart';
+import 'package:easyback/services/APITests.dart';
 import 'package:flutter/material.dart';
 import 'mainpage/ApiPage.dart';
 import 'mainpage/Deployment.dart';
 import 'loginpage.dart';
 import 'package:http/http.dart';
 import 'dart:html' as html;
+
+import 'models/Instance.dart';
 
 
 void main() {
@@ -71,7 +75,7 @@ class Home extends StatelessWidget {
           actions: [
             IconButton(
               icon: Icon(Icons.person,color: Colors.white,),
-              onPressed: () {
+              onPressed: () async {
                 _handleloginpageButton(context);
                 // Login icon pressed
               },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,18 @@
+import 'package:easyback/services/api_auths.dart';
 import 'package:flutter/material.dart';
 import 'mainpage/ApiPage.dart';
 import 'mainpage/Deployment.dart';
 import 'loginpage.dart';
 import 'package:http/http.dart';
+import 'dart:html' as html;
 
 
-void main() => runApp(MaterialApp(
-  home: Home(),
-  debugShowCheckedModeBanner: false, // 디버그 라벨 제거
-));
+void main() {
+  runApp(MaterialApp(
+    home: Home(),
+    debugShowCheckedModeBanner: false, // 디버그 라벨 제거
+  ));
+}
 
 class Home extends StatelessWidget {
   @override
@@ -92,7 +96,8 @@ class Home extends StatelessWidget {
                 SizedBox(height: 20),
                 ElevatedButton(
                   onPressed: () {
-                    _handleloginpageButton(context);
+                    APIAuths.getLogin();
+                    //_handleloginpageButton(context);
                     // "Let's start easybackend" button pressed
                   },
                   style: ElevatedButton.styleFrom(

--- a/lib/models/Instance.dart
+++ b/lib/models/Instance.dart
@@ -1,0 +1,20 @@
+import 'Server.dart';
+
+class Instance {
+  final String instanceId;
+  final String instanceName;
+  final int instanceNumber;
+  final String status;
+  final String? IP;
+  final List<Server> servers;
+
+  Instance.fromJson(Map<String, dynamic> json)
+      : instanceId = json['instance']['instanceId'],
+        instanceName = json['instance']['instanceName'],
+        instanceNumber = json['instance']['instanceNumber'],
+        status = json['instance']['status'],
+        IP = json['instance']['IP'],
+        servers = (json['servers'] as List)
+            .map((e) => Server.fromJson(e))
+            .toList();
+}

--- a/lib/models/Server.dart
+++ b/lib/models/Server.dart
@@ -1,0 +1,20 @@
+import 'ServerVersion.dart';
+
+class Server {
+  final String serverId;
+  final String serverName;
+  final int runningVersion;
+  final int latestVersion;
+  final int? port;
+  final List<ServerVersion> serverVersions;
+
+  Server.fromJson(Map<String, dynamic> json)
+      : serverId = json['server']['serverId'],
+        serverName = json['server']['serverName'],
+        runningVersion = json['server']['runningVersion'],
+        latestVersion = json['server']['latestVersion'],
+        port = json['server']['port'],
+        serverVersions = (json['serverVersions'] as List)
+            .map((e) => ServerVersion.fromJson(e))
+            .toList();
+}

--- a/lib/models/ServerVersion.dart
+++ b/lib/models/ServerVersion.dart
@@ -1,0 +1,10 @@
+class ServerVersion {
+  final int version;
+  final int? port;
+  final String? description;
+
+  ServerVersion.fromJson(Map<String, dynamic> json)
+      : version = json['version'],
+        port = json['port'],
+        description = json['description'];
+}

--- a/lib/services/APIAuths.dart
+++ b/lib/services/APIAuths.dart
@@ -1,6 +1,4 @@
-import 'dart:convert';
 import 'dart:html' as html;
-import 'package:http/http.dart' as http;
 
 class APIAuths {
   static const String baseUrl = 'http://localhost:8080/api';

--- a/lib/services/APIDeployInfos.dart
+++ b/lib/services/APIDeployInfos.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import '../models/Instance.dart';
+import 'package:http/browser_client.dart';
+
+class APIDeployInfos {
+  static const String baseUrl = 'http://localhost:8080/api';
+
+  static Future<List<Instance>> getDeployInfos() async {
+    final url = Uri.parse('$baseUrl/deployInfos/statusAll');
+    final client = BrowserClient()..withCredentials = true;
+    final response = await client.get(
+        url,
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+    );
+
+    if(response.statusCode != 200) {
+      throw Exception('Failed to load deploy infos');
+    }
+
+    final dynamic body = jsonDecode(response.body);
+    final dynamic result = body['result'];
+    final List<Instance> instances = (result['instances'] as List)
+        .map((e) => Instance.fromJson(e))
+        .toList();
+
+    return instances;
+  }
+}

--- a/lib/services/APIDeployments.dart
+++ b/lib/services/APIDeployments.dart
@@ -1,0 +1,4 @@
+class APIDeployments {
+  static const String baseUrl = 'http://localhost:8080/api';
+
+}

--- a/lib/services/APITests.dart
+++ b/lib/services/APITests.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:http/browser_client.dart';
+
+class APITests {
+  static const String baseUrl = 'http://localhost:8080/api';
+
+  static Future<String> testAPI() async {
+    final url = Uri.parse('$baseUrl/tests');
+    final response = await http.get(url);
+
+    if(response.statusCode != 200) {
+      throw Exception('Failed to test API');
+    }
+
+    final dynamic body = jsonDecode(response.body);
+    final String message = body['message'];
+
+    return message;
+  }
+
+  static Future<void> testGetUserInfo() async {
+    final url = Uri.parse('$baseUrl/tests/auth/userInfo');
+    final client = BrowserClient()..withCredentials = true;
+    final response = await client.get(
+        url,
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+    );
+
+    if(response.statusCode != 200) {
+      throw Exception('Failed to get user info');
+    }
+
+    final dynamic body = jsonDecode(response.body);
+    final dynamic result = body['result'];
+    final String username = result['username'];
+
+    print(username);
+  }
+}

--- a/lib/services/api_auths.dart
+++ b/lib/services/api_auths.dart
@@ -1,0 +1,12 @@
+import 'dart:convert';
+import 'dart:html' as html;
+import 'package:http/http.dart' as http;
+
+class APIAuths {
+  static const String baseUrl = 'http://localhost:8080/api';
+
+  static Future<void> getLogin() async {
+    const String url = "$baseUrl/auths/login";
+    html.window.location.href = url;
+  }
+}


### PR DESCRIPTION
#1 
1. 로그인 api 구현, 일단은 메인 화면 중앙의 버튼에만 연동
2. 로그인 완료 시 메인 페이지로 리다이렉트 되도록 구현
3. 리다이렉트를 위해서 정확한 프런트 url 이 필요했는데, 일단은 localhost:3000으로 했고, 그렇기에 3000포트로 고정해서 빌드할 필요가 있음(플러터에서 포트 지정하는 코드를 넣으면 오류나서, 일단은 args에 --web-port=3000을 설정해서 실행함, 다른 컴퓨터에서는 따로 설정할 필요 있음)
4. 세션id는 쿠키에서 관리되서 따로 저장하는 코드 불필요했음
5. 쿠키를 담아서 http 요청할때는 cors 문제가 있어서 프런트, 백엔드 모두 수정, 백엔드는 추후 업데이트 버전 올릴 예정
6. 인스턴스, 서버, 서버목록 등 배포 상태와 관련된 모델 및 json 디코더 제작
7. 배포 상태 정보 요청 api 구현 완료